### PR TITLE
Added maildir-path option for maildir based storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- Add support for maildir storage [[SeanSith](https://github.com/SeanSith)]
+
 ## [0.2.1] - (2020-09-23)
 ### Added
 -  Add option for ui web path [[Alexj12](https://github.com/Alexj12)]

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This cookbook contains the following attributes:
 | ['mailhog']['cors-origin']                       | String  | nil                                                               | If set, a Access-Control-Allow-Origin header is returned for API endpoints   |
 | ['mailhog']['hostname']                          | String  | mailhog.example                                                   | Hostname to use for EHLO/HELO and message IDs                                |
 | ['mailhog']['storage']                           | String  | memory                                                            | Set message storage: memory / mongodb / maildir                              |
+| ['mailhog']['maildir_path']                      | String  | ''                                                                | Path for storage of messages in a file                                       |
 | ['mailhog']['mongodb']['ip']                     | String  | 127.0.0.1                                                         | Host for MongoDB                                                             |
 | ['mailhog']['mongodb']['port']                   | Integer | 27017                                                             | Port for MongoDB                                                             |
 | ['mailhog']['mongodb']['db']                     | String  | mailhog                                                           | MongoDB database name for message storage                                    |

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -53,6 +53,7 @@ default['mailhog']['cors-origin'] = nil
 default['mailhog']['hostname'] = 'mailhog.example'
 
 default['mailhog']['storage'] = 'memory'
+default['mailhog']['maildir_path'] = ''
 default['mailhog']['mongodb']['ip'] = '127.0.0.1'
 default['mailhog']['mongodb']['port'] = 27017
 default['mailhog']['mongodb']['db'] = 'mailhog'

--- a/recipes/binary.rb
+++ b/recipes/binary.rb
@@ -58,6 +58,7 @@ runit_service 'mailhog' do
     :cors_origin => node['mailhog']['cors-origin'],
     :hostname => node['mailhog']['hostname'],
     :storage => node['mailhog']['storage'],
+    :maildir_path => node['mailhog']['maildir_path'],
     :mongodb_ip => node['mailhog']['mongodb']['ip'],
     :mongodb_port => node['mailhog']['mongodb']['port'],
     :mongodb_db => node['mailhog']['mongodb']['db'],

--- a/templates/default/sv-mailhog-run.erb
+++ b/templates/default/sv-mailhog-run.erb
@@ -9,6 +9,7 @@ exec /usr/bin/env MailHog \
   -cors-origin=<%= @options[:cors_origin] %> \
   -hostname=<%= @options[:hostname] %> \
   -storage=<%= @options[:storage] %> \
+  -maildir-path=<%= @options[:maildir_path] %> \
   -mongo-uri=<%= @options[:mongodb_ip] %>:<%= @options[:mongodb_port] %> \
   -mongo-db=<%= @options[:mongodb_db] %> \
   -mongo-coll=<%= @options[:mongodb_collection] %> \


### PR DESCRIPTION
MailHog supports file-based maildir storage. This PR adds support for configuring its path.